### PR TITLE
Supporting case where only BQM is provided

### DIFF
--- a/dwave/samplers/planar/sampler.py
+++ b/dwave/samplers/planar/sampler.py
@@ -76,6 +76,9 @@ class PlanarGraphSampler(dimod.Sampler, dimod.Initialized):
 
         if pos is None:
             pos = {}
+            for v in bqm.variables:
+                # TODO: Ensure that it's sane to put all the vertices at the origin
+                pos[v] = (0,0)
 
         if len(bqm) < 3:
             raise ValueError("The provided BQM must have at least three variables")

--- a/tests/test_planar_sampler.py
+++ b/tests/test_planar_sampler.py
@@ -20,6 +20,27 @@ from dwave.samplers.planar import PlanarGraphSampler
 
 
 class TestGroundStateBQM(unittest.TestCase):
+    def test_noPosProvided_threeVariables(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        bqm.add_interaction('a', 'b', +1.0)
+        bqm.add_interaction('b', 'c', +1.0)
+        bqm.add_interaction('c', 'a', +1.0)
+
+        sample = PlanarGraphSampler().sample(bqm)
+        self.assertDictEqual(sample.first.sample, {'a': 1, 'b': -1, 'c': -1})
+
+    def test_noPosProvided_tenVariables(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        for i in range(0, 10):
+            bqm.add_interaction(i, i+1, 1)
+
+        sample = PlanarGraphSampler().sample(bqm)
+        self.assertDictEqual(sample.first.sample,
+                             {0: 1, 1: -1, 2: 1, 3: -1, 4: 1, 5: -1, 6: 1, 7: -1, 8: 1, 9: -1, 10: 1}
+                             )
+
     def test_NAE3SAT_bqm(self):
         bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
 


### PR DESCRIPTION
- Previously, if no positions were provided this case would fail.  However, we now assume that all the vertices are at the origin and create "pos" accordingly