### PR TITLE
Supporting case where only BQM is provided

### DIFF
--- a/dwave/samplers/planar/planar.py
+++ b/dwave/samplers/planar/planar.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from collections import OrderedDict, Mapping, namedtuple
+from collections import OrderedDict, namedtuple
 
 import networkx as nx
 
@@ -21,7 +21,7 @@ Edge = namedtuple('Edge', ['head', 'tail', 'key'])
 """Represents a (directed) edge in a Multigraph"""
 
 
-def rotation_from_coordinates(G: nx.MultiGraph, pos) -> dict:
+def rotation_from_coordinates(G: nx.MultiGraph, pos: dict) -> dict:
     """Compute the rotation system for a planar G from the node positions.
 
     Args:
@@ -38,22 +38,16 @@ def rotation_from_coordinates(G: nx.MultiGraph, pos) -> dict:
     if not isinstance(G, nx.MultiGraph):
         raise TypeError("expected G to be a MultiGraph")
 
-    if isinstance(pos, Mapping):
-        _pos = pos
-
-        def pos(v):
-            return _pos[v]
-
     rotation = {}
     for u in G.nodes:
-        x0, y0 = pos(u)
+        x0, y0 = pos[u]
 
         def angle(edge):
             if len(edge) == 3:  # generic for Graph or MultiGraph
                 _, v, _ = edge
             else:
                 _, v = edge
-            x, y = pos(v)
+            x, y = pos[v]
             return math.atan2(y - y0, x - x0)
 
         if isinstance(G, nx.MultiGraph):

--- a/dwave/samplers/planar/sampler.py
+++ b/dwave/samplers/planar/sampler.py
@@ -76,6 +76,9 @@ class PlanarGraphSampler(dimod.Sampler, dimod.Initialized):
 
         if pos is None:
             pos = {}
+            for v in bqm.variables:
+                # TODO: Ensure that it's sane to put all the vertices at the origin
+                pos[v] = (0,0)
 
         if len(bqm) < 3:
             raise ValueError("The provided BQM must have at least three variables")

--- a/dwave/samplers/planar/sampler.py
+++ b/dwave/samplers/planar/sampler.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS F ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import networkx
 from dimod import *
 from networkx import is_perfect_matching
 
@@ -74,16 +74,13 @@ class PlanarGraphSampler(dimod.Sampler, dimod.Initialized):
 
         """
 
-        if pos is None:
-            pos = {}
-            for v in bqm.variables:
-                # TODO: Ensure that it's sane to put all the vertices at the origin
-                pos[v] = (0,0)
-
         if len(bqm) < 3:
             raise ValueError("The provided BQM must have at least three variables")
 
         G, off = bqm_to_multigraph(bqm)
+
+        if pos is None:
+            pos = _determine_pos(G)
 
         # apply the rotation system
         r = rotation_from_coordinates(G, pos)
@@ -109,6 +106,15 @@ class PlanarGraphSampler(dimod.Sampler, dimod.Initialized):
 
         ret = SampleSet.from_samples(state, bqm.vartype, 0)
         return ret
+
+
+def _determine_pos(G: MultiGraph) -> dict:
+    is_planar, P = networkx.check_planarity(G)
+    if not is_planar:
+        raise ValueError("The provided BQM does not yield a planar embedding")
+
+    layout = nx.planar_layout(P)
+    return {k: tuple(v) for k, v in layout.items()}
 
 
 def _dual_matching_to_cut(G: MultiGraph, matching: set) -> set:

--- a/dwave/samplers/planar/util.py
+++ b/dwave/samplers/planar/util.py
@@ -18,7 +18,7 @@ from networkx import MultiGraph
 from numpy import number
 
 
-def bqm_to_multigraph(bqm: BinaryQuadraticModel) -> tuple[MultiGraph, number]:
+def bqm_to_multigraph(bqm: BinaryQuadraticModel): # -> tuple[MultiGraph, number]:
     """
     Args:
         bqm: Binary quadratic model to be sampled.

--- a/tests/test_planar_sampler.py
+++ b/tests/test_planar_sampler.py
@@ -20,6 +20,27 @@ from dwave.samplers.planar import PlanarGraphSampler
 
 
 class TestGroundStateBQM(unittest.TestCase):
+    def test_noPosProvided_threeVariables(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        bqm.add_interaction('a', 'b', +1.0)
+        bqm.add_interaction('b', 'c', +1.0)
+        bqm.add_interaction('c', 'a', +1.0)
+
+        sample = PlanarGraphSampler().sample(bqm)
+        self.assertDictEqual(sample.first.sample, {'a': 1, 'b': -1, 'c': -1})
+
+    def test_noPosProvided_tenVariables(self):
+        bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
+
+        for i in range(0, 10):
+            bqm.add_interaction(i, i+1, 1)
+
+        sample = PlanarGraphSampler().sample(bqm)
+        self.assertDictEqual(sample.first.sample,
+                             {0: 1, 1: -1, 2: 1, 3: -1, 4: 1, 5: -1, 6: 1, 7: -1, 8: 1, 9: -1, 10: 1}
+                             )
+
     def test_NAE3SAT_bqm(self):
         bqm = dimod.BinaryQuadraticModel.empty(dimod.SPIN)
 

--- a/tests/test_planar_sampler.py
+++ b/tests/test_planar_sampler.py
@@ -62,9 +62,7 @@ class TestGroundStateBQM(unittest.TestCase):
                 bqm.add_interaction((x, y), (x + 1, y + 1), 1)
                 bqm.add_interaction((x, y), (x, y + 1), 1)
 
-        def pos(v): return v
-
-        sample = PlanarGraphSampler().sample(bqm, pos)
+        sample = PlanarGraphSampler().sample(bqm)
 
         self.assertEqual(set(sample.first.sample.values()), {-1, +1})
         self.assertDictEqual(
@@ -111,9 +109,7 @@ class TestGroundStateBQM(unittest.TestCase):
                 bqm.add_interaction((x, y), (x + 1, y + 1), -1)
                 bqm.add_interaction((x, y), (x, y + 1), -1)
 
-        def pos(v): return v
-
-        sample = PlanarGraphSampler().sample(bqm, pos)
+        sample = PlanarGraphSampler().sample(bqm)
 
         # should all be the same
         self.assertEqual(set(sample.first.sample.values()), {-1})


### PR DESCRIPTION
- Previously, if no positions were provided this case would fail.  However, we now generate a planar-embedding iff one exists; otherwise we throw an exception
- Removed dependency upon Mapping since that's causing CI issues
- Tests succeed locally but not on the CI server